### PR TITLE
the return statement on line 296 stops bool uniforms not working

### DIFF
--- a/src/ui/opparamspanel/patch_portparams.js
+++ b/src/ui/opparamspanel/patch_portparams.js
@@ -293,7 +293,7 @@ CABLES.UI.initPortInputListener = function (op, index)
                     ele.addClass("invalid");
                     console.log("invalid number", op.portsIn[index]);
                 }
-                return;
+                // return;
             }
             else
             {


### PR DESCRIPTION
So i removed the commented out section to allow the custom shader op to create bool uniforms. issue #1668
It then threw the error invalid number in the console.
The bool value wouldn't come through to the shader.
Removing the return statement visible in the commit fixes the problem.
There's still a console.log of an invalid number but at least it gets through to the bool section and passes the value through.
I tested the math parser with the number op extensively and it still seems to work okay.
I'm not sure what removing this could break so feedback would be appreciated.
  