### PR TITLE
Transparent popout canvas

### DIFF
--- a/html/ui/templates/tab_preferences.html
+++ b/html/ui/templates/tab_preferences.html
@@ -455,6 +455,16 @@
         </div>
         <div class="row">
             <div class="cute-5-phone prefLeft">
+                <span class="prefswitch switch switch-text switch-left" data-setting="transparentpopout" data-value="false">Off</span>
+                <span class="prefswitch switch switch-text switch-right" data-setting="transparentpopout" data-value="true">On</span>
+            </div>
+            <div class="cute-7-phone prefRight">
+                <h3>{{texts.title_transparentpopout}}</h3>
+                {{texts.subtitle_transparentpopout}}
+            </div>
+        </div>
+        <div class="row">
+            <div class="cute-5-phone prefLeft">
                 <input class="valinput" data-setting="authorName" value=""/>
             </div>
             <div class="cute-7-phone prefRight">

--- a/src/ui/components/tabs/tab_preferences.js
+++ b/src/ui/components/tabs/tab_preferences.js
@@ -119,6 +119,7 @@ export default class Preferences
         this.setSwitchValue("openlastproject", userSettings.get("openlastproject") || false);
         this.setSwitchValue("openfullscreen", userSettings.get("openfullscreen") || false);
         this.setSwitchValue("maximizerenderer", userSettings.get("maximizerenderer") || false);
+        this.setSwitchValue("transparentpopout", userSettings.get("transparentpopout") || false);
 
         this.setInputValue("authorName", userSettings.get("authorName") || "");
         this.setSwitchValue("escape_closetabs", userSettings.get("escape_closetabs") || false);

--- a/src/ui/text.js
+++ b/src/ui/text.js
@@ -274,6 +274,9 @@ export const GuiText =
         "title_maximizerenderer": "Maximize renderer on start",
         "subtitle_maximizerenderer": "",
 
+        "title_transparentpopout": "Transparent popout canvas",
+        "subtitle_transparentpopout": "Allows transparent backgrounds for popout canvas window (Standalone only)",
+
         "title_authorName": "Author name for created ops",
         "subtitle_authorName": "",
 


### PR DESCRIPTION
This Pull Request adds an Editor Preference option for Cables standalone to open the Popout Canvas in a transparent window.  

related to issue [7428](https://github.com/cables-gl/cables/issues/7428)

Created with Gemini AI, tested in MacOS 26.3